### PR TITLE
Fix for #17, checks and alerts on permissions.

### DIFF
--- a/time_unix.c
+++ b/time_unix.c
@@ -90,6 +90,10 @@ kt_setfreq(double frequency)
 	tx.freq = (long)floor(frequency * (65536 * 1e6));
 	errno = 0;
 	i = ntp_adjtime(&tx);
+	if(i == -1 && errno == EPERM) {
+		Fail(NULL, 0, "Insufficient permissions");
+	}
+
 	/* XXX: what is the correct error test here ? */
 	assert(i >= 0);
 }


### PR DESCRIPTION
Although not running as root is clearly a user error, it triggers an assertion and doesn't alert the user why. It then appears to go unresponsive.

This small patch fixes #17 and causes it to alert the user and fail cleanly.

As an aside, thank you for this project.
