### PR TITLE
time_unix.c: add uClibc support

### DIFF
--- a/time_unix.c
+++ b/time_unix.c
@@ -40,6 +40,12 @@
 
 #include <sys/timex.h>
 
+/* uClibc configured without NTP_LEGACY doesn't provide a ntp_adjtime alias */
+#include <features.h>
+#if defined(__UCLIBC__) && !defined(__UCLIBC_NTP_LEGACY__)
+#define ntp_adjtime	adjtimex
+#endif
+
 #include "ntimed.h"
 
 static double adj_offset = 0;


### PR DESCRIPTION
uClibc doesn't provide a ntp_adjtime alias for adjtimex unless
UCLIBC_NTP_LEGACY is enabled (which it isn't by default).

Detect this configuration and alias the call to adjtimex with a define
instead.

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>