### PR TITLE
Fix broken call to ntp_adjtime.

### DIFF
--- a/time_unix.c
+++ b/time_unix.c
@@ -89,7 +89,7 @@ kt_setfreq(struct ocx *ocx, double frequency)
 #endif
 
 	tx.status = STA_PLL | STA_FREQHOLD;
-	tx.modes = MOD_FREQUENCY;
+	tx.modes |= MOD_FREQUENCY;
 	tx.freq = (long)floor(frequency * (65536 * 1e6));
 	errno = 0;
 	i = ntp_adjtime(&tx);


### PR DESCRIPTION
The 'tx.modes' variable was being overwritten with MOD_FEQUENCY, instead of using a bitwise-or, which i belive should be correct.
This has changed the "KERNPLL" printout from returning 5 = TIME_ERROR to 0 = TIME_OK also.
