### PR TITLE
Add LDFLAGS variable to Makefile

### DIFF
--- a/configure
+++ b/configure
@@ -110,6 +110,8 @@ else
 	echo ''
 	echo "CFLAGS += -Wall -Werror"
 	echo ''
+	echo "LDFLAGS += "
+	echo ''
 
 	for f in ${HDRS}
 	do
@@ -142,7 +144,7 @@ else
 
 	echo
 	echo "ntimed-client:	${l}"
-	echo "	\${CC} \${CFLAGS} -o ntimed-client ${l} -lm"
+	echo "	\${CC} \${CFLAGS} \${LDFLAGS} -o ntimed-client ${l} -lm"
 	echo
 	echo "clean:"
 	echo "	rm -f ${l} ntimed-client"


### PR DESCRIPTION
In order to run ntimed through ns3 (www.nsnam.org) DCE (Direct Code Execution), I need to compile ntimed with the following flags.
This PR adds an empty LDFLAGS to the Makefile. 

If you want I can send another PR in which "configure" would save into the makefile the passed parameters such as:
$ CFLAGS="-fPIC -U_FORTIFY_SOURCE" LDFLAGS="-pie -rdynamic" sh ./configure
