### PR TITLE
suspicious reassignment before the old value has been used

### DIFF
--- a/combine_delta.c
+++ b/combine_delta.c
@@ -26,12 +26,12 @@
  * Source Combiner based on delta-pdfs
  * ===================================
  *
- * The basic principle here is that sources gives us four values:
- *   - The highest low value were the probability is zero.
- *   - The lowest high value were the probability is zero.
+ * The basic principle here is that sources give us four values:
+ *   - The highest low value where the probability is zero
+ *   - The lowest high value where the probability is zero
  *   - The most probable value
  *   - The relative trust in that value [0...1]
- * Together this defines a triangular probability density function.
+ * Together these define a triangular probability density function (pdf).
  *
  * The combiner adds all these pdfs' together weighted by trust
  * and finds the highest probability which sports a quorum.

--- a/ntimed.h
+++ b/ntimed.h
@@ -138,7 +138,6 @@ void TS_RunTest(struct ocx *ocx);
 
 /* todo.c -- todo-list scheduler **************************************/
 
-
 enum todo_e {
 	TODO_INTR	= -2,	// Signal received
 	TODO_FAIL	= -1,	// Break out of TODO_Run()

--- a/ntp_packet.c
+++ b/ntp_packet.c
@@ -76,7 +76,6 @@
 static void
 ntp64_2ts(struct timestamp *ts, const uint8_t *ptr)
 {
-
 	INIT_OBJ(ts, TIMESTAMP_MAGIC);
 	ts->sec = Be32dec(ptr) - NTP_UNIX;
 	ts->frac = (uint64_t)Be32dec(ptr + 4) << 32ULL;
@@ -85,7 +84,6 @@ ntp64_2ts(struct timestamp *ts, const uint8_t *ptr)
 static void
 ntp32_2ts(struct timestamp *ts, const uint8_t *ptr)
 {
-
 	INIT_OBJ(ts, TIMESTAMP_MAGIC);
 	ts->sec = Be16dec(ptr);
 	ts->frac = (uint64_t)Be16dec(ptr + 2) << 48ULL;

--- a/time_stuff.c
+++ b/time_stuff.c
@@ -67,7 +67,6 @@ ts_fixstorage(struct timestamp *storage)
 struct timestamp *
 TS_Nanosec(struct timestamp *storage, int64_t sec, int64_t nsec)
 {
-
 	storage = ts_fixstorage(storage);
 
 	assert(sec >= 0);
@@ -83,7 +82,6 @@ TS_Nanosec(struct timestamp *storage, int64_t sec, int64_t nsec)
 struct timestamp *
 TS_Double(struct timestamp *storage, double d)
 {
-
 	assert(d >= 0.0);
 	storage = ts_fixstorage(storage);
 
@@ -261,5 +259,3 @@ TS_RunTest(struct ocx *ocx)
 	Debug(ocx, "TS_RunTest: %d failures\n", nf);
 	AZ(nf);
 }
-
-

--- a/time_unix.c
+++ b/time_unix.c
@@ -101,7 +101,6 @@ kt_setfreq(struct ocx *ocx, double frequency)
 static enum todo_e __match_proto__(todo_f)
 kt_ticker(struct ocx *ocx, struct todolist *tdl, void *priv)
 {
-
 	(void)ocx;
 	AN(tdl);
 	AZ(priv);
@@ -238,7 +237,6 @@ kt_sleep(double dur)
 void
 Time_Unix(struct todolist *tdl)
 {
-
 	AN(tdl);
 	TB_Step = kt_step;
 	TB_Adjust = kt_adjust;
@@ -256,7 +254,6 @@ Time_Unix(struct todolist *tdl)
 void
 Time_Unix_Passive(void)
 {
-
 	TB_Sleep = kt_sleep;
 	TB_Now = kt_now;
 }

--- a/time_unix.c
+++ b/time_unix.c
@@ -27,7 +27,7 @@
  * =============
  *
  * Implement the timebase functions on top of a modern UNIX kernel which
- * has the some version of the Mills/Kamp kernel PLL code and either
+ * has some version of the Mills/Kamp kernel PLL code and either
  * [gs]ettimeofday(2) or better: clock_[gs]ettime(2) API.
  *
  */


### PR DESCRIPTION
There is some useless code before the call to ntp_adjtime.