### PR TITLE
Turn hard coded values into parameters.

### DIFF
--- a/main_sim_client.c
+++ b/main_sim_client.c
@@ -139,7 +139,7 @@ simfile_readline(struct ocx *ocx, struct todolist *tdl, void *priv)
 			u1 -= sf->t0;
 			TS_Nanosec(&sf->when, u1, u2);
 			dt = TS_Diff(&sf->when, &t0);
-			if (dt >= 1e-3) {
+			if (dt >= param_sim_min_sched) {
 				TODO_ScheduleAbs(tdl, simfile_readline, priv,
 				    &sf->when, 0.0, "Readline");
 				return (TODO_OK);

--- a/ntp_filter.c
+++ b/ntp_filter.c
@@ -115,8 +115,7 @@ nf_filter(struct ocx *ocx, const struct ntp_peer *np)
 	}
 
 	// This is almost never a good sign.
-	if (r > 2048) {
-		/* XXX: 2048 -> param */
+	if (r > param_ntp_filter_ancient) {
 		Put(ocx, OCX_TRACE, "NF ancient ref %.3e\n", r);
 		return;
 	}

--- a/param_tbl.h
+++ b/param_tbl.h
@@ -65,8 +65,8 @@ PARAM_NTP_FILTER(ntp_filter_threshold,
 PARAM_NTP_FILTER(ntp_filter_ancient,
 	256, 4096, 2048,
 	"Packet delays exceeding the average by this amount are too old."
-	" Theese events are logged."
-	"  Setting this too high and the clock man become eratic."
+	" These events are logged."
+	"  Setting this too high and the clock may become erratic."
 	"  Setting it too low throws away useful timestamps."
 )
 
@@ -124,7 +124,7 @@ PARAM_PLL_STD(pll_std_mode1_step,
 	"Treshold for stepping clock at startup.\n\n"
 	"Reducing this will step the clock at smaller errors."
 	" Increasing this makes the PLL more tolerant and"
-	" reduce the chance that the clock is stepped."
+	" reduces the chance that the clock is stepped."
 )
 
 PARAM_PLL_STD(pll_std_mode1_rt,

--- a/param_tbl.h
+++ b/param_tbl.h
@@ -38,8 +38,10 @@
 /* name, min, max, default, docs */
 
 #ifdef PARAM_CLIENT
-PARAM_CLIENT(poll_rate, 16.0,	4096.0,	64.0, "")
-PARAM_CLIENT(foo, 16.0,	4096.0,	64.0, "")
+PARAM_CLIENT(poll_rate, 16.0,	4096.0,	64.0, "Client poll rate")
+PARAM_CLIENT(sim_min_sched,
+	1e-6, 1e-2, 1e-3,
+	"Minimum delay before simulator scheduling")
 #endif
 
 #ifdef PARAM_NTP_FILTER
@@ -58,6 +60,14 @@ PARAM_NTP_FILTER(ntp_filter_threshold,
 	"Packet delays exceeding the average by this factor are untrustworthy."
 	"  Setting this too high increases noise from (mild) congestion."
 	"  Setting it too low throws away adequate timestamps."
+)
+
+PARAM_NTP_FILTER(ntp_filter_ancient,
+	256, 4096, 2048,
+	"Packet delays exceeding the average by this amount are too old."
+	" Theese events are logged."
+	"  Setting this too high and the clock man become eratic."
+	"  Setting it too low throws away useful timestamps."
 )
 
 #endif
@@ -107,6 +117,32 @@ PARAM_PLL_STD(pll_std_p_limit,
 	"Reducing this will make the PLL more resistent to noise,"
 	" but going too far it will not be able to steer the clock fast enough."
 	"  Increasing this makes the PLL more agile and prone to noise."
+)
+
+PARAM_PLL_STD(pll_std_mode1_step,
+	1e-6, 3e2, 1e-3,
+	"Treshold for stepping clock at startup.\n\n"
+	"Reducing this will step the clock at smaller errors."
+	" Increasing this makes the PLL more tolerant and"
+	" reduce the chance that the clock is stepped."
+)
+
+PARAM_PLL_STD(pll_std_mode1_rt,
+	1e-3, 1e3, 2,
+	"Cut off value for internal offset in PLL-mode 1\n\n"
+	"Increasing this will delay the initial clock step."
+)
+
+PARAM_PLL_STD(pll_std_mode1_weight,
+	1e-3, 1e3, 3,
+	"Cut off value for weight in PLL-mode 1\n\n"
+	"Increasing this will delay the initial clock step."
+)
+
+PARAM_PLL_STD(pll_std_mode2_rt,
+	1e-3, 1e3, 6,
+	"Cut off value for internal offset in PLL-mode 2\n\n"
+	"Increasing this will delay the transition to mode 3."
 )
 
 #endif

--- a/pll_std.c
+++ b/pll_std.c
@@ -77,8 +77,9 @@ pll_std(struct ocx *ocx, double offset, double weight)
 	case 1: /* Wait until we have a good estimate, then step */
 
 		rt = TS_Diff(&t0, &pll_t0);
-		if (rt > 2.0 && weight > 3) {		// XXX param
-			if (fabs(offset) > 1e-3)	// XXX param
+		if (rt > param_pll_std_mode1_rt
+		   && weight > param_pll_std_mode1_weight) {
+			if (fabs(offset) > param_pll_std_mode1_step)
 				TB_Step(ocx, -offset);
 			pll_mode = 2;
 			pll_t0 = t0;
@@ -88,7 +89,7 @@ pll_std(struct ocx *ocx, double offset, double weight)
 	case 2: /* Wait for another good estimate, then PLL */
 
 		rt = TS_Diff(&t0, &pll_t0);
-		if (rt > 6.0) {
+		if (rt > param_pll_std_mode2_rt) {
 			pll_b = pll_a / param_pll_std_i_init;
 			pll_t0 = t0;
 			pll_mode = 3;


### PR DESCRIPTION
Values affecting mode 1 and 2 of the standard PLL have been converted to
 tune-able parameters. The min and max values are far apart and may need to be
 tightened up. The scheduling delay in main_sim_client.c and the cut off
  for ancient packets in ntp_filter.c has veen turned into parameters too.