### PR TITLE
Backgrounding support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,9 +101,6 @@ Stop ntpd if it is running, and then::
 
 That should synchronize your clock to those servers.
 
-Because this is a preview release, the process will not "daemonize"
-into the background.
-
 The '-t /tmp/somefile' arguments tells it to write a full blow-by-blow
 tracefile, for analysis and debugging.
 
@@ -114,8 +111,8 @@ What happens when you run it ?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 After a few seconds, your clock will be stepped if necessary.
-(In the final version, this is where the process daemonizes into the
-background -- from which point you can trust your clock to be good.)
+Then the program will get into the background you can trust
+your clock to be good.
 
 In the next 30-60 seconds, the PLL will eliminate any residual phase
 error and from this point in time, your computer's clock should be

--- a/configure
+++ b/configure
@@ -68,6 +68,7 @@ SRCS='
 	param.c
 	pll_std.c
 	suckaddr.c
+	sys_unix.c
 	time_sim.c
 	time_stuff.c
 	time_unix.c

--- a/main_client.c
+++ b/main_client.c
@@ -71,6 +71,7 @@ main_client(int argc, char *const *argv)
 
 	tdl = TODO_NewList();
 	Time_Unix(tdl);
+	Background_Unix_Init();
 
 	PLL_Init();
 

--- a/ntimed.h
+++ b/ntimed.h
@@ -93,6 +93,12 @@ void PLL_Init(void);
 
 int SA_Equal(const void *sa1, size_t sl1, const void *sa2, size_t sl2);
 
+/* sys_*.c */
+
+typedef void sb_background_f(struct ocx*);
+extern sb_background_f *SB_Background;
+void Background_Unix_Init(void);
+
 /* time_sim.c -- Simulated timebase ***********************************/
 
 extern double Time_Sim_delta;

--- a/pll_std.c
+++ b/pll_std.c
@@ -92,6 +92,13 @@ pll_std(struct ocx *ocx, double offset, double weight)
 			pll_b = pll_a / param_pll_std_i_init;
 			pll_t0 = t0;
 			pll_mode = 3;
+			/*
+			 * Put process in the background if the client
+			 * configured that.
+			 */
+			if (SB_Background != NULL) {
+				SB_Background(ocx);
+			}
 		}
 		break;
 
@@ -133,6 +140,7 @@ pll_std(struct ocx *ocx, double offset, double weight)
 		p_term = -offset * used_a;
 		pll_integrator += p_term * used_b;
 		dur = dt;
+
 		break;
 	default:
 		WRONG("Wrong PLL state");

--- a/sys_unix.c
+++ b/sys_unix.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2017 Rune Magnussen
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ *  UNIX-specific stuff
+ * ====================
+ * Function to put the calling process into the background.
+ */
+#include <stdlib.h>
+#include <unistd.h>
+#include <errno.h>
+#include "ntimed.h"
+
+sb_background_f *SB_Background = NULL;
+
+static void __match_proto__(sb_background_f)
+unix_background(struct ocx *ocx)
+{
+	if (daemon(1, 1)) {
+		Fail(ocx, errno, "daemon() failed\n");
+	}
+	Debug(ocx, "BACKGROUND\n");
+}
+
+/*
+ * Register backgrounding function.
+ * Programs calling this may end up in the background.
+ */
+void
+Background_Unix_Init(void)
+{
+	SB_Background = unix_background;
+}

--- a/sys_unix.c
+++ b/sys_unix.c
@@ -33,12 +33,18 @@
 
 sb_background_f *SB_Background = NULL;
 
+static int bg = 0;
+
 static void __match_proto__(sb_background_f)
 unix_background(struct ocx *ocx)
 {
+	AZ(bg);
+
 	if (daemon(1, 1)) {
 		Fail(ocx, errno, "daemon() failed\n");
 	}
+
+	bg++;
 	Debug(ocx, "BACKGROUND\n");
 }
 


### PR DESCRIPTION
Put ntimed-client in the background once the PLL is stable.
    
  Add platform specific back-grounding for UNIX-like systems and make the main client use that to slip into the background once the PLL is stable. This abstraction should ease porting  to non-UNIX systems.